### PR TITLE
Keyboard event work

### DIFF
--- a/client/src/components/Canvas/MindMap.js
+++ b/client/src/components/Canvas/MindMap.js
@@ -250,6 +250,12 @@ const MindMap = () => {
         });
     }, []);
 
+    const handleKeyPress = (e) => {
+        if (e.key === "Delete") {
+            deleteNodes(selectedNode);
+        }
+    };
+
     const handleReset = () => {
         if (ymapRef.current) {
             // ymap이 초기화되었을 경우에만 clear() 메서드를 호출합니다.
@@ -587,7 +593,7 @@ const MindMap = () => {
 
     const { graph, events } = state;
     return (
-        <div>
+        <div onKeyDown={handleKeyPress}>
             <button onClick={handleReset}>리셋 MindMap</button>
             <PreventRefresh />
             <h2 id="eventSpanHeading"></h2>
@@ -611,7 +617,6 @@ const MindMap = () => {
                         );
                     },
                     oncontext: openNodeContextMenu,
-                    // click: openNodeContextMenu,
                 }}
                 style={{ height: "100vh" }}
             />

--- a/client/src/components/Canvas/eventHandler.js
+++ b/client/src/components/Canvas/eventHandler.js
@@ -128,6 +128,7 @@ export const handleAddTextNode = (
     setSelectedNode,
     setIsCreatingText
 ) => {
+    if (event.nodes.length === 0) setSelectedNode(null);
     if (!isCreatingText) return;
 
     const { pointer } = event;


### PR DESCRIPTION
노드가 아닌 캔버스를 클릭 시, selectedNode state를 초기화하게 바꿔주었고, Delete 키를 통하여 노드를 삭제할 수 있도록 하였습니다.