### PR TITLE
CC -> FC 마이그레이션 과정 중 생긴 버그들 수정

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -251,7 +251,7 @@ const App = () => {
 
     const createSession = async (sessionId) => {
         const response = await axios.post(
-            APPLICATION_SERVER_URL + "api/session",
+            APPLICATION_SERVER_URL + "api/sessions",
             {
                 customSessionId: sessionId,
             },

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -46,6 +46,14 @@ const App = () => {
         };
     }, []);
 
+    useEffect(() => {
+        if (appState.session) {
+            if (appState.mySessionId !== undefined) {
+                joinSession();
+            }
+        }
+    }, [appState]);
+
     const handleChangeSessionId = (e) => {
         const sessionId = e.target.value.replace(/#/g, "");
         if (sessionId.match(/^[a-zA-Z0-9]+$/)) {
@@ -67,7 +75,6 @@ const App = () => {
 
     const handleCreateSession = () => {
         setAppState({ ...appState, mySessionId: makeid(8) });
-        joinSession();
     };
 
     const handleJoinSession = (callback) => {
@@ -138,8 +145,8 @@ const App = () => {
             },
         });
 
-        setAppState({ ...appState, session: OV.initSession() }, () => {
-            let mySession = appState.session;
+        setAppState((prevState) => {
+            const mySession = OV.initSession();
 
             mySession.on("streamCreated", (event) => {
                 let subscriber = mySession.subscribe(event.stream, undefined);
@@ -197,6 +204,8 @@ const App = () => {
                         );
                     });
             });
+
+            return { ...prevState, session: mySession };
         });
     };
 
@@ -245,7 +254,6 @@ const App = () => {
 
     const getToken = async () => {
         const sessionId = await createSession(appState.mySessionId);
-        console.log("Session ID: ", sessionId);
         return await createToken(sessionId);
     };
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -149,7 +149,7 @@ const App = () => {
                 setAppState({ ...appState, subscribers: subscribers });
             });
 
-            mySession.om("streamDestroyed", (event) => {
+            mySession.on("streamDestroyed", (event) => {
                 deleteSubscriber(event.stream.streamManager);
             });
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -47,12 +47,10 @@ const App = () => {
     }, []);
 
     useEffect(() => {
-        if (appState.session) {
-            if (appState.mySessionId !== undefined) {
-                joinSession();
-            }
+        if (appState.mySessionId !== undefined) {
+            joinSession();
         }
-    }, [appState]);
+    }, [appState.mySessionId]);
 
     const handleChangeSessionId = (e) => {
         const sessionId = e.target.value.replace(/#/g, "");


### PR DESCRIPTION
- 기존 CC에서 setState에 두 번째 인자로 콜백함수를 넘겨주어 상태가 완전히 변경된 후 작업을 처리하도록 구성되어 있었음.
- 이는 FC의 useState훅에서는 허용되지 않는 방법으로, 이를 수정하였음.
- useEffect 의존성 배열에 인자를 잘못 전달하던 것을 수정하였음.